### PR TITLE
XRAYJENKINS-85 fix support of proxy exclusions

### DIFF
--- a/src/main/java/com/xpandit/plugins/xrayjenkins/Utils/ProxyUtil.java
+++ b/src/main/java/com/xpandit/plugins/xrayjenkins/Utils/ProxyUtil.java
@@ -58,7 +58,7 @@ public class ProxyUtil {
 
     private static Pattern makeUrlPattern(String noProxyHostElement) {
         final String regexp;
-        if (noProxyHostElement.indexOf("://") >= 0) {
+        if (noProxyHostElement.contains("://")) {
             // looks like an URL pattern; it's not supported in Jenkins in general, but it was in previous versions
             // of this plugin (2.3.0, 2.3.1), so let's keep that unchanged in case someone ever used it successfuly...
             regexp = noProxyHostElement.replace(".", "\\.").replace("*", ".*");

--- a/src/main/java/com/xpandit/plugins/xrayjenkins/Utils/ProxyUtil.java
+++ b/src/main/java/com/xpandit/plugins/xrayjenkins/Utils/ProxyUtil.java
@@ -12,14 +12,20 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 
 import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ProxyUtil {
     private ProxyUtil() {}
 
     /**
      * Gets the Proxy Bean based on the jenkins configuration.
-     * 
+     *
      * @return If there is an proxy configured, it will return the bean with this information, otherwise, it will return null.
      */
     @Nullable
@@ -31,11 +37,36 @@ public class ProxyUtil {
         if (proxyConfiguration != null) {
             final HttpHost proxy = getProxy(proxyConfiguration);
             final CredentialsProvider credentialsProvider = getCredentialsProvider(proxyConfiguration);
-            
-            return new HttpRequestProvider.ProxyBean(proxy, credentialsProvider, proxyConfiguration.getNoProxyHostPatterns());
+            final List<Pattern> noProxyUrlPatterns = getNoProxyUrlPatterns(proxyConfiguration.noProxyHost);
+
+            return new HttpRequestProvider.ProxyBean(proxy, credentialsProvider, noProxyUrlPatterns);
         }
-        
+
         return null;
+    }
+
+    // Similar to hudson.ProxyConfiguration.getNoProxyHostPatterns(String), but returns URL patterns, instead of domain patterns.
+    private static List<Pattern> getNoProxyUrlPatterns(String noProxyHost) {
+        if (StringUtils.isBlank(noProxyHost)) {
+            return Collections.emptyList();
+        }
+        return Stream.of(noProxyHost.split("[ \t\n,|]+"))
+            .filter(StringUtils::isNotEmpty)
+            .map(ProxyUtil::makeUrlPattern)
+            .collect(Collectors.toList());
+    }
+
+    private static Pattern makeUrlPattern(String noProxyHostElement) {
+        final String regexp;
+        if (noProxyHostElement.indexOf("://") >= 0) {
+            // looks like an URL pattern; it's not supported in Jenkins in general, but it was in previous versions
+            // of this plugin (2.3.0, 2.3.1), so let's keep that unchanged in case someone ever used it successfuly...
+            regexp = noProxyHostElement.replace(".", "\\.").replace("*", ".*");
+        } else {
+            // looks like a domain pattern; *.blah.com becomes https?://[^/:]*\.blah\.com(:[0-9]+)?(/.*)?
+            regexp = "https?://" + noProxyHostElement.replace(".", "\\.").replace("*", "[^/:]*") + "(:[0-9]+)?(/.*)?";
+        }
+        return Pattern.compile(regexp);
     }
 
     private static HttpHost getProxy(ProxyConfiguration proxyConfiguration) {
@@ -50,7 +81,7 @@ public class ProxyUtil {
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         final AuthScope authScope = new AuthScope(proxyConfiguration.name, proxyConfiguration.port);
         final Credentials credentials = new UsernamePasswordCredentials(proxyConfiguration.getUserName(), proxyConfiguration.getPassword());
-        
+
         credentialsProvider.setCredentials(authScope, credentials);
         return credentialsProvider;
     }


### PR DESCRIPTION
The original fix for [XRAYJENKINS-85](https://jira.xpand-it.com/browse/XRAYJENKINS-85) (#17) by Hugo Braz is not working as one would expect (as pointed by @pyrrhosii in #17 already).

The problem is that it's based on `hudson.ProxyConfiguration.getNoProxyHostPatterns()`, which is a list of patterns for matching domain names (usually in Jenkins, you configure the proxy exclusions list to something like "`blah.com|foo.bar|*.foo.bar`", at least that's how what's expected everywhere else). But in the XRay plugin, this list is used to configure an `HttpRequestProvider.ProxyBean`, and in `HttpRequestProvider` this patterns list is used to test the full target URL directly, and not just its host component (see `createHttpClient(...)`, `withProxy(...)` and `ProxyBean.useProxy(...)`).

To reproduce the issue, it's simple:
- set Jenkins proxy to some random non-resolvable domain ("*whatever*"), and a random port (in */jenkins/pluginManager/advanced*)
- add `my-jira-server` to the proxy exclusion list
- go to global configuration, set `https://my-jira-server` as the XRay base URL
- click "*Test connection*"
- see in log that this tries to go through the proxy (`java.net.UnknownHostException: whatever`)
- now, change the proxy exclusion to `https://my-jira-server/*` and test the connection again
- see this time the proxy is not used (`java.net.UnknownHostException: my-jira-server`).

Which gives a convenient workaround for this issue, but is really not how this exclusion list usually works...

In this PR, I propose to replace `getNoProxyHostPatterns()` with something similar but which actually produces a list of URL patterns instead of domain names patterns. This way:
- there is no need to change anything in `com.xpandit.xray:client-core` (although this would be a better/cleaner alternative probably, but I couldn't find the sources repository for this lib so I can't send a PR anyway)
- it is possible to preserve the 2.3.0/2.3.1 behavior for anything which looks like an URL pattern already (in case some users have already found the workaround themselves, and have set `https://my-jira-server/*` in there own proxy exclusions configuration)
