### PR TITLE
Add method to retrieve Xray environment variables

### DIFF
--- a/src/main/java/com/xpandit/plugins/xrayjenkins/services/enviromentvariables/XrayEnvironmentInjectAction.java
+++ b/src/main/java/com/xpandit/plugins/xrayjenkins/services/enviromentvariables/XrayEnvironmentInjectAction.java
@@ -51,4 +51,8 @@ public class XrayEnvironmentInjectAction implements EnvironmentContributingActio
     public String getUrlName() {
         return null;
     }
+
+    public Map<String, String> getXrayEnvVarsResult() {
+        return newVariablesToAdd;
+    }
 }


### PR DESCRIPTION
This PR adds a public getter, getXrayEnvVarsResult(), to XrayEnvironmentInjectAction so Pipeline users can access the Xray environment variables that are already stored on the build action.

Currently, the plugin creates an XrayEnvironmentInjectAction containing the Xray result variables, such as:

* XRAY_IS_REQUEST_SUCCESSFUL
* XRAY_RAW_RESPONSE
* XRAY_TEST_EXECS
* XRAY_ISSUES_MODIFIED
* XRAY_TESTS

However, due to Jenkins Pipeline limitations, EnvironmentContributingAction#buildEnvVars(...) is not called for Pipeline jobs. As a result, these values are not exposed through the normal Pipeline env object, even though the plugin has already created and attached the action to the build.

This change does not alter the existing environment injection behavior. It only exposes the already stored variable map through a public getter, so Pipeline users have a supported way to read the values from the attached action.

### Motivation

The plugin documentation states that Xray environment variables are not set in Pipeline projects due to Jenkins limitations. This is correct for the automatic environment injection mechanism.

However, the data is still available internally in the XrayEnvironmentInjectAction instance attached to the build. Without a public accessor, Pipeline users currently need to use reflection or parse the Jenkins console log to retrieve values such as the created Test Execution key.

### Both workarounds are fragile:

* Reflection depends on private implementation details and may require Jenkins script approvals.
* Console log parsing depends on log formatting and can break when log messages change.
* Direct REST API usage bypasses the Jenkins plugin entirely and duplicates functionality already implemented by the plugin.

Adding getXrayEnvVarsResult() provides a small, explicit, and safer extension point for Pipeline users.

### What changed

Added a public getter to XrayEnvironmentInjectAction:

```java
public Map<String, String> getXrayEnvVarsResult() {
    return newVariablesToAdd;
}
```

This allows Pipeline code to read the variables from the build action after an Xray import step has completed.

### Example Pipeline usage

The following example shows how a Jenkins Shared Library can run the existing XrayImportBuilder step and then read the variables from the newly added XrayEnvironmentInjectAction.

src/com/example/XrayHelper.groovy

```java
package com.example
class XrayHelper implements Serializable {
    private static final String XRAY_ACTION_CLASS =
        'com.xpandit.plugins.xrayjenkins.services.enviromentvariables.XrayEnvironmentInjectAction'
    /**
     * Runs the Xray import step and returns the variables from the newly added
     * XrayEnvironmentInjectAction.
     */
    static Map<String, String> xrayImportAndReadVars(def script, Map config) {
        // Capture all existing Xray actions before running the import.
        def beforeActions = getXrayActions(script)
        // Run the actual Jenkins/Xray import step.
        script.step(config)
        // Capture all Xray actions after the import.
        def afterActions = getXrayActions(script)
        // Find the action that was added by this specific import step.
        def newActions = afterActions.findAll { afterAction ->
            !beforeActions.any { beforeAction ->
                beforeAction.is(afterAction)
            }
        }
        if (newActions.size() == 0) {
            script.error "No new XrayEnvironmentInjectAction found after XrayImportBuilder"
        }
        if (newActions.size() > 1) {
            script.error "Expected exactly one new XrayEnvironmentInjectAction, but found ${newActions.size()}"
        }
        return readXrayVarsFromAction(script, newActions[0])
    }
    /**
     * Returns all XrayEnvironmentInjectAction instances currently attached to the build.
     */
    private static List getXrayActions(def script) {
        return script.currentBuild.rawBuild.getActions().findAll { action ->
            action.getClass().getName() == XRAY_ACTION_CLASS
        }
    }
    /**
     * Reads the Xray variables through the public getter on the action.
     */
    private static Map<String, String> readXrayVarsFromAction(def script, def xrayAction) {
        def vars = xrayAction.getXrayEnvVarsResult()
        if (vars == null) {
            script.error "Xray action returned null from getXrayEnvVarsResult()"
        }
        if (!(vars instanceof Map)) {
            script.error "getXrayEnvVarsResult() did not return a Map. Actual type: ${vars.getClass().getName()}"
        }
        return vars as Map<String, String>
    }
}
```

vars/xrayImport.groovy

```java
import com.example.XrayHelper
def call(Map config) {
    def xrayVars = XrayHelper.xrayImportAndReadVars(this, config)
    // Optionally copy selected values into the Pipeline environment.
    env.XRAY_IS_REQUEST_SUCCESSFUL = xrayVars['XRAY_IS_REQUEST_SUCCESSFUL'] ?: ''
    env.XRAY_TEST_EXECS = xrayVars['XRAY_TEST_EXECS'] ?: ''
    env.XRAY_RAW_RESPONSE = xrayVars['XRAY_RAW_RESPONSE'] ?: ''
    env.XRAY_ISSUES_MODIFIED = xrayVars['XRAY_ISSUES_MODIFIED'] ?: ''
    env.XRAY_TESTS = xrayVars['XRAY_TESTS'] ?: ''
    echo "XRAY_IS_REQUEST_SUCCESSFUL = ${env.XRAY_IS_REQUEST_SUCCESSFUL}"
    echo "XRAY_TEST_EXECS = ${env.XRAY_TEST_EXECS}"
    return xrayVars
}
```

Jenkinsfile example

```groovy
stage('Import results to Xray') {
    steps {
        script {
            def xrayVars = xrayImport([
                $class: 'XrayImportBuilder',
                serverInstance: 'xray',
                endpointName: '/junit',
                importFilePath: 'target/surefire-reports/*.xml',
                projectKey: 'ABC'
            ])
            echo "Created/updated Test Executions: ${xrayVars['XRAY_TEST_EXECS'] ?: 'NOT SET'}"
        }
    }
}
```

### Multiple imports

The example intentionally compares the list of Xray actions before and after the import step. This allows Pipeline users to associate the returned variables with the specific import call that created them.

For example:

```groovy
def junitVars = xrayImport([
    $class: 'XrayImportBuilder',
    serverInstance: 'xray',
    endpointName: '/junit',
    importFilePath: 'target/surefire-reports/*.xml',
    projectKey: 'ABC'
])
def cucumberVars = xrayImport([
    $class: 'XrayImportBuilder',
    serverInstance: 'xray',
    endpointName: '/cucumber',
    importFilePath: 'target/cucumber/*.json',
    projectKey: 'ABC'
])
echo "JUnit Test Executions: ${junitVars['XRAY_TEST_EXECS'] ?: 'NOT SET'}"
echo "Cucumber Test Executions: ${cucumberVars['XRAY_TEST_EXECS'] ?: 'NOT SET'}"
```

This avoids relying on “the last action” globally and keeps each import result associated with the corresponding import step.

### Compatibility

This change is backward compatible.

* Existing Freestyle behavior is unchanged.
* Existing Pipeline behavior is unchanged unless users explicitly read the action through the new getter.
* No existing method signatures are changed.
* The automatic environment variable injection mechanism remains unchanged.

### Why this is useful

This provides a supported alternative to reflection and log parsing for Pipeline users who need access to Xray import results after using XrayImportBuilder.

It does not remove the documented Pipeline limitation around automatic environment injection. Instead, it provides a practical way to access the same data from the action that the plugin already attaches to the build.