### PR TITLE
Remove usages of Commons Lang 2

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,12 @@
+{
+  "scanSettings": {
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>
 			<artifactId>json-simple</artifactId>
-			<version>1.1</version>
+			<version>1.1.1</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.jenkins-ci.plugins</groupId>
 	<artifactId>xray-connector</artifactId>
-	<version>2.6.1</version>
+	<version>2.6.2-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
 	<properties>
@@ -44,7 +44,7 @@
 		<connection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
 		<developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-		<tag>xray-connector-2.6.1</tag>
+		<tag>xray-connector-2.5.0</tag>
 	</scm>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
 		<version>3.43</version>
-		<relativePath />
+		<relativePath/>
 	</parent>
 
 	<groupId>org.jenkins-ci.plugins</groupId>
@@ -89,7 +89,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.2.2-atlassian-1</version>
+			<version>2.8.9</version>
 		</dependency>
 		 <dependency>
 		    <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
 		<version>3.43</version>
-		<relativePath/>
+		<relativePath />
 	</parent>
 
 	<groupId>org.jenkins-ci.plugins</groupId>
 	<artifactId>xray-connector</artifactId>
-	<version>2.6.1-SNAPSHOT</version>
+	<version>2.6.1</version>
 	<packaging>hpi</packaging>
 
 	<properties>
@@ -44,7 +44,7 @@
 		<connection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
 		<developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-		<tag>xray-connector-2.5.0</tag>
+		<tag>xray-connector-2.6.1</tag>
 	</scm>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.10.8</version>
+			<version>2.13.0</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins/credentials -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.9</version>
+			<version>2.9.0</version>
 		</dependency>
 		 <dependency>
 		    <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.jenkins-ci.plugins</groupId>
 	<artifactId>xray-connector</artifactId>
-	<version>2.6.2-SNAPSHOT</version>
+	<version>2.7.0-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
 	<properties>
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>com.xpandit.xray</groupId>
 			<artifactId>client-core</artifactId>
-    		<version>2.6.0.1</version>
+    		<version>2.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.10.8</version>
+			<version>2.13.2.1</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins/credentials -->
 		<dependency>

--- a/src/main/java/com/xpandit/plugins/xrayjenkins/Utils/FormUtils.java
+++ b/src/main/java/com/xpandit/plugins/xrayjenkins/Utils/FormUtils.java
@@ -6,7 +6,6 @@ import com.xpandit.plugins.xrayjenkins.model.ServerConfiguration;
 import com.xpandit.plugins.xrayjenkins.model.XrayInstance;
 import hudson.util.ListBoxModel;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
 
 import java.util.List;
 
@@ -33,7 +32,7 @@ public class FormUtils {
                 throw new XrayJenkinsGenericException("Null hosting type found");
             } else {
                 String alias = sc.getAlias();
-                if (StringUtils.isBlank(sc.getCredentialId())) {
+                if (sc.getCredentialId() == null || sc.getCredentialId().isBlank()) {
                     alias = "[User Auth required] " + alias;
                 }
 

--- a/src/main/java/com/xpandit/plugins/xrayjenkins/model/CredentialResolver.java
+++ b/src/main/java/com/xpandit/plugins/xrayjenkins/model/CredentialResolver.java
@@ -1,5 +1,6 @@
 package com.xpandit.plugins.xrayjenkins.model;
 
+import java.util.Objects;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
@@ -10,7 +11,6 @@ import hudson.model.Run;
 import hudson.model.User;
 import java.util.Collections;
 import org.acegisecurity.Authentication;
-import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -37,7 +37,7 @@ public class CredentialResolver {
     }
     
     private void resolveCredential() {
-        if (StringUtils.isNotBlank(this.credentialId)) {
+        if (this.credentialId != null && !this.credentialId.isBlank()) {
             this.credentials = findCredentialById();
         }
     }
@@ -61,7 +61,7 @@ public class CredentialResolver {
         List<StandardCredentials> userScopedCredentials = CredentialUtil.getAllUserScopedCredentials(run.getParent(), buildUserAuth);
         StandardCredentials credentialsMatched = userScopedCredentials
                 .stream()
-                .filter(cred -> StringUtils.equals(cred.getId(), this.credentialId))
+                .filter(cred -> Objects.equals(cred.getId(), this.credentialId))
                 .findFirst()
                 .orElse(null);
 

--- a/src/main/resources/com/xpandit/plugins/xrayjenkins/task/XrayImportBuilder/config.jelly
+++ b/src/main/resources/com/xpandit/plugins/xrayjenkins/task/XrayImportBuilder/config.jelly
@@ -94,7 +94,7 @@
 
     <f:section name="dynamicFields">
         <f:entry title="Parameters">
-            <p id="configurableFields_${descriptor.defaultBuildID()}" style="border-left:solid;border-color:#00a3ac;width:50vw"></p>
+            <p id="configurableFields_${descriptor.defaultBuildID()}" style="padding-left:6px;border-left:solid;border-color:#00a3ac;width:50vw"></p>
         </f:entry>
     </f:section>
 


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this
functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- `FormUtils` and `CredentialResolver` were the last three `org.apache.commons.lang` call sites —
  `isBlank` / `isNotBlank` become plain `String` checks and `StringUtils.equals` becomes
  `Objects.equals`. The rest of the plugin already imports `org.apache.commons.lang3`, so this just
  removes the leftover mix; no dependency change.

### Testing done

`mvn -B -ntp clean verify` fails locally in `maven-compiler-plugin` with
`NoSuchFileException: target/classes/META-INF/annotations/hudson.Extension` — an old
annotation-indexer versus a modern JDK, reproducible on an unmodified checkout.

The `ban-commons-lang-2` enforcer rule was left disabled: it needs parent POM `6.2116.v7501b_67dc517` or newer and this plugin is on `3.43`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
